### PR TITLE
build: :construction_worker: Include generated files in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typescript": "^5.1.6"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && mkdir -p build/generated && cp src/generated/* build/generated/",
     "genProto": "protoc --plugin=protoc-gen-grpc=./node_modules/.bin/grpc_tools_node_protoc_plugin -I src/proto --js_out=import_style=commonjs,binary:./src/generated ./src/proto/*.proto && protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts -I src/proto --ts_out=./src/generated ./src/proto/*.proto",
     "test": "jest",
     "lint": "prettier --check ."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
   ],
   "exclude": [
     "node_modules",
-    "**/*.test.ts"
+    "**/*.test.ts",
+    "**/*.test.ts.snap"
   ]
 }


### PR DESCRIPTION
Make sure the generated files are included in the build & ignore the test snap files in the build

